### PR TITLE
Add ability to append Nova filters to resource tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
     }
   ],
   "require": {
+    "php": "^7.3|^8.0",
+    "ext-json": "*",
     "illuminate/support": "^8.0",
     "illuminate/filesystem": "^8.0",
     "illuminate/testing": "^8.0",

--- a/src/Traits/MakesNovaHttpRequests.php
+++ b/src/Traits/MakesNovaHttpRequests.php
@@ -10,14 +10,15 @@ trait MakesNovaHttpRequests
     /**
      * Makes a nova get request.
      *
-     * @param string     $resourceKey
-     * @param string|int $key
+     * @param string $resourceKey
+     * @param null $key
+     * @param string $query
      *
      * @return \Illuminate\Testing\TestResponse
      */
-    protected function novaGet($resourceKey, $key = null): TestResponse
+    protected function novaGet($resourceKey, $key = null, $query = ''): TestResponse
     {
-        return $this->novaRequest('get', $resourceKey . ($key ? "/$key" : ''));
+        return $this->novaRequest('get', $resourceKey . ($key ? "/$key" : ''), [], $query);
     }
 
     /**


### PR DESCRIPTION
This PR adds an ability to append Nova filters to `getResource` requests.
It reveals `withFilter` method that can be chained easily in tests.

Example:

```php
use App\Nova\Filters\UserRoleFilter;

$this->modelClass::factory(10)->create();

$this
    ->withFilter(UserRoleFilter::class, 'admin')
    ->getResources();
```

As an array:

```php
use App\Nova\Filters\UserRoleFilter;
use App\Nova\Filters\UserStatusFilter;

$this->modelClass::factory(10)->create();

$this
    ->withFilter([
        UserRoleFilter::class => 'admin',
        UserStatusFilter::class => 'active',
    ])
    ->getResources();
```