### PR TITLE
Laravel 9 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^7.3|^8.0.2",
     "ext-json": "*",
-    "illuminate/support": "^8.0",
-    "illuminate/filesystem": "^8.0",
-    "illuminate/testing": "^8.0",
-    "illuminate/contracts": "^8.0"
+    "illuminate/support": "^8.0|^9.0",
+    "illuminate/filesystem": "^8.0|^9.0",
+    "illuminate/testing": "^8.0|^9.0",
+    "illuminate/contracts": "^8.0|^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel 9.x

Note:

`public function setUp()` needs to be `protected function setUp()` in `NovaResourceTestCase.stub` but I'm not sure how that would play out with Laravel 8, so I'm leaving that for now.